### PR TITLE
Test suite annotation fixes

### DIFF
--- a/tests/libpeas/introspection/introspection-callable.c
+++ b/tests/libpeas/introspection/introspection-callable.c
@@ -34,7 +34,7 @@ introspection_callable_default_init (IntrospectionCallableInterface *iface)
 
 /**
  * introspection_callable_call_with_return:
- * callable:
+ * @callable:
  *
  * Returns: (transfer full):
  */
@@ -54,8 +54,8 @@ introspection_callable_call_with_return (IntrospectionCallable *callable)
 
 /**
  * introspection_callable_call_single_arg:
- * callable:
- * called: (out):
+ * @callable:
+ * @called: (out):
  */
 void
 introspection_callable_call_single_arg (IntrospectionCallable *callable,
@@ -72,10 +72,10 @@ introspection_callable_call_single_arg (IntrospectionCallable *callable,
 
 /**
  * introspection_callable_call_multi_args:
- * callable:
- * called_1: (out):
- * called_2: (out):
- * called_3: (out):
+ * @callable:
+ * @called_1: (out):
+ * @called_2: (out):
+ * @called_3: (out):
  */
 void
 introspection_callable_call_multi_args (IntrospectionCallable *callable,


### PR DESCRIPTION
Turns out that the crashes I was experiencing in the test suite last night weren't the result of a 32-/64-bit incompatibility — just that the annotations in the test suite weren't being picked up on by g-ir-scanner as they weren't properly former. Consequently, the GIR had the wrong direction information for arguments, and thus they were marshalled incorrectly. This commit fixes the problem for me, and the test suites now pass.
