### PR TITLE
Updated to the new gtk-mac-integration APIs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,7 +136,7 @@ AM_CONDITIONAL(OS_OSX, test "$os_osx" = "yes")
 if test "$os_osx" = "yes"; then
 	AC_DEFINE([OS_OSX],[1],[Defined if os is Mac OSX])
 
-	PKG_CHECK_MODULES(IGE_MAC, ige-mac-integration)
+	PKG_CHECK_MODULES(GTK_MAC, gtk-mac-integration)
 fi
 
 dnl ================================================================

--- a/libpeas/Makefile.am
+++ b/libpeas/Makefile.am
@@ -4,7 +4,7 @@ INCLUDES =								\
 	-I$(top_srcdir)							\
 	-I$(srcdir)							\
 	$(PEAS_CFLAGS)							\
-	$(IGE_MAC_CFLAGS)						\
+	$(GTK_MAC_CFLAGS)						\
 	$(GCOV_CFLAGS)							\
 	$(WARN_CFLAGS)							\
 	$(DISABLE_DEPRECATED)						\
@@ -16,7 +16,7 @@ libpeas_1_0_la_LDFLAGS = \
 	-version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) \
 	-export-dynamic -no-undefined -export-symbols-regex "^[^_].*"
 
-libpeas_1_0_la_LIBADD = $(PEAS_LIBS) $(IGE_MAC_LIBS)
+libpeas_1_0_la_LIBADD = $(PEAS_LIBS) $(GTK_MAC_LIBS)
 
 INST_H_FILES =			\
 	peas-plugin-info.h	\

--- a/libpeas/peas-dirs.c
+++ b/libpeas/peas-dirs.c
@@ -24,7 +24,7 @@
 #endif
 
 #ifdef OS_OSX
-#include <ige-mac-bundle.h>
+#include <gtk-mac-bundle.h>
 #endif
 
 #include "peas-dirs.h"
@@ -42,11 +42,11 @@ peas_dirs_get_data_dir (void)
   data_dir = g_build_filename (win32_dir, "share", "libpeas-1.0", NULL);
   g_free (win32_dir);
 #elif defined (OS_OSX)
-  IgeMacBundle *bundle = ige_mac_bundle_get_default ();
+  GtkMacBundle *bundle = gtk_mac_bundle_get_default ();
 
-  if (ige_mac_bundle_get_is_app_bundle (bundle))
+  if (gtk_mac_bundle_get_is_app_bundle (bundle))
     {
-      const gchar *bundle_data_dir = ige_mac_bundle_get_datadir (bundle);
+      const gchar *bundle_data_dir = gtk_mac_bundle_get_datadir (bundle);
 
       data_dir = g_build_filename (bundle_data_dir, "libpeas-1.0", NULL);
     }
@@ -74,11 +74,11 @@ peas_dirs_get_lib_dir (void)
   lib_dir = g_build_filename (win32_dir, "lib", "libpeas-1.0", NULL);
   g_free (win32_dir);
 #elif defined (OS_OSX)
-  IgeMacBundle *bundle = ige_mac_bundle_get_default ();
+  GtkMacBundle *bundle = gtk_mac_bundle_get_default ();
 
-  if (ige_mac_bundle_get_is_app_bundle (bundle))
+  if (gtk_mac_bundle_get_is_app_bundle (bundle))
     {
-      const gchar *path = ige_mac_bundle_get_resourcesdir (bundle);
+      const gchar *path = gtk_mac_bundle_get_resourcesdir (bundle);
 
       lib_dir = g_build_filename (path, "lib", "libpeas-1.0", NULL);
     }
@@ -126,11 +126,11 @@ peas_dirs_get_locale_dir (void)
 
   g_free (win32_dir);
 #elif defined (OS_OSX)
-  IgeMacBundle *bundle = ige_mac_bundle_get_default ();
+  GtkMacBundle *bundle = gtk_mac_bundle_get_default ();
 
-  if (ige_mac_bundle_get_is_app_bundle (bundle))
+  if (gtk_mac_bundle_get_is_app_bundle (bundle))
     {
-      locale_dir = g_strdup (ige_mac_bundle_get_localedir (bundle));
+      locale_dir = g_strdup (gtk_mac_bundle_get_localedir (bundle));
     }
   else
     {


### PR DESCRIPTION
Hello. **gtk-mac-integration** project, which is hosted on GitHub [there](https://github.com/jralls/gtk-mac-integration), has the new API.

FYI, `ige-mac-integration` has been changed to `gtk-mac-integration` and so on, there is no `IGE` prefix anymore.